### PR TITLE
Made `app` a global, not context value

### DIFF
--- a/muffin_jinja2.py
+++ b/muffin_jinja2.py
@@ -49,13 +49,13 @@ class Plugin(BasePlugin):
             self.cfg.loader = FileSystemLoader(
                 self.cfg.template_folders, encoding=self.cfg.encoding)
 
-        self.context_processor(lambda: {'app': self.app})
         self.env = jinja2.Environment(
             auto_reload=self.cfg.auto_reload,
             cache_size=self.cfg.cache_size,
             extensions=self.cfg.extensions,
             loader=self.cfg.loader,
         )
+        self.env.globals['app'] = app
 
         @self.register
         @jinja2.contextfunction


### PR DESCRIPTION
The main difference between context and global values is that
context values cannot be accessed from imported macros by default:

`{% from "helpers.html" import my_macro %}` -
such macro is cached and thus cannot access current context;
for it to access context, it should be called like this -
`{% from "helpers.html" import my_macro with context %}`
which is less efficient.

`app` object is safe to use as global because its direct value will not change.
We may also want to allow using `register()` decorator for objects, not just functions:

```
app.ps.jinja2.register(my_obj, 'my_obj_name')
```

What do you think?
